### PR TITLE
Simplify installation instructions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
       run: conda list
     - name: Test ProteinDT import
       shell: bash --login {0}
-      run: python -c 'from ProteinDT.models.model_SDE import VESDE'
+      run: python -c 'from ProteinDT.models.model_ProteinText import ProteinTextModel'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
     - name: Log conda environment
       shell: bash --login {0}
       run: conda list
+    - name: Test ProteinDT import
+      shell: bash --login {0}
+      run: python -c 'from ProteinDT.models.model_SDE import VESDE'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Tests
+on:
+- push
+- pull_request
+
+jobs:
+  # Installs the conda environment and ProteinDT package
+  install:
+    name: Test ProteinDT installation
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Could also test on the beta M1 macOS or other runners
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os:
+        - ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    # Use mamba instead of conda
+    - name: Install conda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: ProteinDT
+        environment-file: environment.yml
+        auto-activate-base: false
+        miniforge-variant: Mambaforge
+        miniforge-version: 'latest'
+        use-mamba: true
+      # Installs ProteinDT package into the activated conda environment
+    - name: Install ProteinDT
+      shell: bash --login {0}
+      run: pip install .
+      # Log conda environment contents
+    - name: Log conda environment
+      shell: bash --login {0}
+      run: conda list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
         miniforge-variant: Mambaforge
         miniforge-version: 'latest'
         use-mamba: true
+      # Installs fair-esm package into the activated conda environment without dependencies
+    - name: Install fair-esm
+      shell: bash --login {0}
+      run: pip install fair-esm[esmfold]==2.0.0 --no-dependencies # Override deepspeed==0.5
       # Installs ProteinDT package into the activated conda environment
     - name: Install ProteinDT
       shell: bash --login {0}

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,5 @@ dependencies:
   - einops
   - mdtraj
   - pip:
-      - fair-esm[esmfold]==2.0.0 # for ESM folding
       - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
 #      - git+https://github.com/aqlaboratory/openfold@4b41059694619831a7db195b7e0988fc4ff3a307

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - networkx
   - scikit-learn
   - pytorch::pytorch=1.10
+  - pytorch::cudatoolkit # pyg installs cudatoolkit even if cpuonly is requested
   - transformers
   - lxml
   - lmdb # for TAPE
@@ -27,5 +28,5 @@ dependencies:
   - einops
   - mdtraj
   - pip:
-      - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
+#      - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
 #      - git+https://github.com/aqlaboratory/openfold@4b41059694619831a7db195b7e0988fc4ff3a307

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - networkx
   - scikit-learn
   - pytorch::pytorch=1.10
-  - pytorch::cpuonly # remove for GPU environment
   - transformers
   - lxml
   - lmdb # for TAPE
@@ -30,4 +29,4 @@ dependencies:
   - pip:
       - fair-esm[esmfold]==2.0.0 # for ESM folding
       - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
-      - git+https://github.com/aqlaboratory/openfold@4b41059694619831a7db195b7e0988fc4ff3a307
+#      - git+https://github.com/aqlaboratory/openfold@4b41059694619831a7db195b7e0988fc4ff3a307

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - pip
+  - pip=18
   - numpy
   - networkx
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - networkx
   - scikit-learn
   - pytorch::pytorch=1.10
-  - pytorch::cudatoolkit # pyg installs cudatoolkit even if cpuonly is requested
+  - nvidia::cudatoolkit # pyg installs cudatoolkit even if cpuonly is requested
   - transformers
   - lxml
   - lmdb # for TAPE

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,31 @@
+name: ProteinDT
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - numpy
+  - networkx
+  - scikit-learn
+  - pytorch::pytorch=1.10
+  - transformers
+  - lxml
+  - lmdb # for TAPE
+  - seqeval
+  - openai # for baseline ChatGPT
+  - accelerate # for baseline Galactica
+  - matplotlib # for visualization
+  - h5py # for binding editing
+  - biopython
+  - pyg::pyg=2.0
+  - pyg::pytorch-scatter
+  - pyg::pytorch-sparse
+  - pyg::pytorch-cluster
+  - dm-tree # for ESM folding
+  - omegaconf
+  - ml-collections
+  - einops
+  - mdtraj
+  - pip:
+      - fair-esm[esmfold]==2.0.0 # for ESM folding
+      - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
+      - git+https://github.com/aqlaboratory/openfold@4b41059694619831a7db195b7e0988fc4ff3a307

--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,12 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - pip
   - numpy
   - networkx
   - scikit-learn
   - pytorch::pytorch=1.10
+  - pytorch::cpuonly # remove for GPU environment
   - transformers
   - lxml
   - lmdb # for TAPE

--- a/environment.yml
+++ b/environment.yml
@@ -28,5 +28,5 @@ dependencies:
   - einops
   - mdtraj
   - pip:
-#      - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
+      - git+https://github.com/NVIDIA/dllogger@0540a43971f4a8a16693a9de9de73c1072020769
 #      - git+https://github.com/aqlaboratory/openfold@4b41059694619831a7db195b7e0988fc4ff3a307


### PR DESCRIPTION
I found the current installation process challenging because it combines many calls to conda and pip. I simplified it by creating a conda .yml file to install almost all of the dependencies. A few still are pip installed. One needs to be pip installed outside the .yml file because of the `--no-dependencies` argument. ProteinDT itself is also pip installed after the conda environment is created. Open Fold is currently commented out because the pinned version fails in a system without a GPU.

I created a GitHub Actions workflow for testing that the new installation process works and that ProteinDT can be imported. Python 3.7 gave some errors, but I was eventually able to resolve those by switching to an older version of pip. We could use this workflow to test if the installation also works with newer Python.

I have not been able to test that ProteinDT actually runs in this environment or that the GPU support works. That should be tested before merging. If this looks okay, I can also update the readme before merging.