### PR TITLE
Use new environment in readme and fix mkl version bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,45 +19,13 @@ Authors: Shengchao Liu, Yanjing Li, Zhuoxinran Li, Anthony Gitter, Yutao Zhu, Ji
 ## 1 Environment
 
 ```
-conda create -n ProteinDT python=3.7
+conda env create -f environment.yml
 conda activate ProteinDT
-
-conda install -y numpy networkx scikit-learn
-
-pip install torch==1.10.*
-
-pip install transformers
-pip install lxml
-
-# for TAPE
-pip install lmdb
-pip install seqeval
-
-# for baseline ChatGPT
-pip install openai
-
-# for baseline Galactica
-pip install accelerate
-
-# for visualization
-pip install matplotlib
-
-# for binding editing
-pip install h5py
-pip install torch_geometric==2.0 torch_scatter torch_sparse torch_cluster
-pip install biopython
-
 # for ESM folding
-pip install "fair-esm[esmfold]"
-pip install dm-tree omegaconf ml-collections einops
-pip install fair-esm[esmfold]==2.0.0  --no-dependencies # Override deepspeed==0.5 
-pip install 'dllogger @ git+https://github.com/NVIDIA/dllogger.git'
-pip install 'openfold @ git+https://github.com/aqlaboratory/openfold.git@4b41059694619831a7db195b7e0988fc4ff3a307'
-
-conda install -c conda-forge -yq mdtraj
-
+pip install fair-esm[esmfold]==2.0.0 --no-dependencies
 # for ProteinDT
 pip install .
+
 ```
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.7
   - pip=18
+  - mkl=2024.0
   - numpy
   - networkx
   - scikit-learn


### PR DESCRIPTION
The goal of #2 was to greatly simplify the installation by reducing the number of commands someone needs to run to create the environment. This updates to readme to use the minimal commands. These are the same commands that run in [GitHub Actions](https://github.com/chao1224/ProteinDT/actions).

I still haven't tested on a GPU though.